### PR TITLE
added performance checking module

### DIFF
--- a/app/src/androidTest/java/com/canvearth/canvearth/ServerInterfaceTest.java
+++ b/app/src/androidTest/java/com/canvearth/canvearth/ServerInterfaceTest.java
@@ -11,10 +11,14 @@ import com.canvearth.canvearth.server.FBPixelManager;
 import com.canvearth.canvearth.utils.BitmapUtils;
 import com.canvearth.canvearth.utils.Configs;
 import com.canvearth.canvearth.utils.Constants;
+import com.canvearth.canvearth.utils.DatabaseUtils;
 import com.canvearth.canvearth.utils.MathUtils;
+import com.canvearth.canvearth.utils.PixelUtils;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -25,15 +29,20 @@ import java.util.Random;
 @RunWith(AndroidJUnit4.class)
 public class ServerInterfaceTest {
 
-    @Before
-    public void setup() {
+    @BeforeClass
+    public static void setup() {
         Configs.TESTING = true;
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        DatabaseUtils.clearDev();
     }
 
     @Test
     public void leafPixelReadTest() {
         FBPixelManager fBPixelManager = FBPixelManager.getInstance();
-        ArrayList<PixelData> samePixelData = makeSamplePixelData(
+        ArrayList<PixelData> samePixelData = PixelUtils.makeBatchPixelData(
                 new PixelData(0, 0, Constants.LEAF_PIXEL_ZOOM_LEVEL),
                 20,
                 20);
@@ -50,7 +59,7 @@ public class ServerInterfaceTest {
     @Test
     public void leafPixelWriteTest() {
         FBPixelManager fBPixelManager = FBPixelManager.getInstance();
-        ArrayList<PixelData> samePixelData = makeSamplePixelData(new PixelData(0, 0, Constants.LEAF_PIXEL_ZOOM_LEVEL),
+        ArrayList<PixelData> samePixelData = PixelUtils.makeBatchPixelData(new PixelData(0, 0, Constants.LEAF_PIXEL_ZOOM_LEVEL),
                 20,
                 20);
 
@@ -59,10 +68,7 @@ public class ServerInterfaceTest {
         // Write black color to the random pixel
         Random random = new Random();
         PixelData randomPixelData = samePixelData.get(random.nextInt(20 * 20));
-        fBPixelManager.writePixelAsync(randomPixelData, new Color(0L, 0L, 0L), () -> {
-            Log.d("leafPixelWriteTest", "Succeed");
-        });
-
+        fBPixelManager.writePixelSync(randomPixelData, new Color(0L, 0L, 0L));
         // You have to unwatch pixel
         fBPixelManager.unwatchPixels(samePixelData);
     }
@@ -70,7 +76,7 @@ public class ServerInterfaceTest {
     @Test
     public void leafPixelWriteReadTest() {
         FBPixelManager fBPixelManager = FBPixelManager.getInstance();
-        ArrayList<PixelData> samePixelData = makeSamplePixelData(new PixelData(0, 0, Constants.LEAF_PIXEL_ZOOM_LEVEL),
+        ArrayList<PixelData> samePixelData = PixelUtils.makeBatchPixelData(new PixelData(0, 0, Constants.LEAF_PIXEL_ZOOM_LEVEL),
                 20,
                 20);
         // You have to watch pixel first..
@@ -91,7 +97,7 @@ public class ServerInterfaceTest {
     public void bitmapReadTest() {
         FBPixelManager fBPixelManager = FBPixelManager.getInstance();
         ArrayList<PixelData> samePixelData
-                = makeSamplePixelData(new PixelData(0, 0, Constants.LEAF_PIXEL_ZOOM_LEVEL), 8, 8);
+                = PixelUtils.makeBatchPixelData(new PixelData(0, 0, Constants.LEAF_PIXEL_ZOOM_LEVEL), 8, 8);
         // You have to watch pixel first..
         fBPixelManager.watchPixels(samePixelData);
         Color green = new Color(0L, 255L, 0L);
@@ -110,19 +116,5 @@ public class ServerInterfaceTest {
         }
         // You have to unwatch pixel
         fBPixelManager.unwatchPixels(samePixelData);
-    }
-
-    private ArrayList<PixelData> makeSamplePixelData(PixelData startPixelData, int numX, int numY) {
-        ArrayList<PixelData> pixelData = new ArrayList<>();
-        for (int x = 0; x < numX; x++) {
-            for (int y = 0; y < numY; y++) {
-                PixelData nearbyPixelData = new PixelData(
-                        startPixelData.x + x,
-                        startPixelData.y + y,
-                        startPixelData.zoom);
-                pixelData.add(nearbyPixelData);
-            }
-        }
-        return pixelData;
     }
 }

--- a/app/src/androidTest/java/com/canvearth/canvearth/ServerPerformanceTest.java
+++ b/app/src/androidTest/java/com/canvearth/canvearth/ServerPerformanceTest.java
@@ -1,0 +1,98 @@
+package com.canvearth.canvearth;
+
+import android.graphics.Bitmap;
+import android.support.test.runner.AndroidJUnit4;
+import android.util.Log;
+
+import com.canvearth.canvearth.pixel.Color;
+import com.canvearth.canvearth.pixel.PixelData;
+import com.canvearth.canvearth.server.FBPixel;
+import com.canvearth.canvearth.server.FBPixelManager;
+import com.canvearth.canvearth.utils.BitmapUtils;
+import com.canvearth.canvearth.utils.Configs;
+import com.canvearth.canvearth.utils.Constants;
+import com.canvearth.canvearth.utils.DatabaseUtils;
+import com.canvearth.canvearth.utils.MathUtils;
+import com.canvearth.canvearth.utils.PixelUtils;
+import com.canvearth.canvearth.utils.TimeUtils;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+
+@RunWith(AndroidJUnit4.class)
+public class ServerPerformanceTest {
+
+    @BeforeClass
+    public static void setup() {
+        Configs.TESTING = true;
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        DatabaseUtils.clearDev();
+    }
+
+    @Test
+    public void pixelWritePerformanceTest() {
+        final String TAG = "ServerPerformanceTest/pixelWritePerformanceTest";
+        FBPixelManager fBPixelManager = FBPixelManager.getInstance();
+        ArrayList<PixelData> samePixelData = PixelUtils.makeBatchPixelData(
+                new PixelData(0, 0, Constants.LEAF_PIXEL_ZOOM_LEVEL), 10, 10);
+
+        // You have to watch pixel first..
+        fBPixelManager.watchPixels(samePixelData);
+        // Write black color to the random pixel
+        long startTime = System.nanoTime();
+        int totalUpdated = 0;
+        for (PixelData pixelData : samePixelData) {
+            PixelData lastUpdatedPixelData
+                    = fBPixelManager.writePixelSync(pixelData, new Color(0L, 0L, 0L));
+            int numUpdated = pixelData.zoom - lastUpdatedPixelData.zoom + 1;
+            totalUpdated += numUpdated;
+        }
+        long endTime = System.nanoTime();
+        long elapsedTime =TimeUnit.NANOSECONDS.toMillis(endTime - startTime);
+        float averageUpdated = ((float) totalUpdated) / samePixelData.size();
+        float averageElapsedTime = elapsedTime / samePixelData.size();
+        Log.i(TAG, "Average Elapsed Time: " + averageElapsedTime
+                + ", Average Updated Number: " + averageUpdated);
+        // You have to unwatch pixel
+        fBPixelManager.unwatchPixels(samePixelData);
+    }
+
+    @Test
+    public void bitmapReadPerformanceTest() {
+        final String TAG = "ServerPerformanceTest/bitmapReadPerformanceTest";
+        FBPixelManager fBPixelManager = FBPixelManager.getInstance();
+        ArrayList<PixelData> samePixelData = PixelUtils.makeBatchPixelData(
+                new PixelData(0, 0, Constants.LEAF_PIXEL_ZOOM_LEVEL), 16, 16);
+
+        // You have to watch pixel first..
+        fBPixelManager.watchPixels(samePixelData);
+        Color green = new Color(0L, 255L, 0L);
+        for (PixelData pixelData : samePixelData) {
+            fBPixelManager.writePixelSync(pixelData, green);
+        }
+        PixelData zoomedOutPixelData8x8 = new PixelData(0, 0, Constants.LEAF_PIXEL_ZOOM_LEVEL - 3);
+        long elapsedTime8x8 = TimeUtils.measureTimeMillis((Object object) -> {
+            fBPixelManager.getBitmapSync(zoomedOutPixelData8x8, 3);
+        });
+        Log.v(TAG, "Elapsed Time For getting 8x8 bitmap: " + elapsedTime8x8);
+        PixelData zoomedOutPixelData16x16 = new PixelData(0, 0, Constants.LEAF_PIXEL_ZOOM_LEVEL - 4);
+        long elapsedTime16x16 = TimeUtils.measureTimeMillis((Object object) -> {
+            fBPixelManager.getBitmapSync(zoomedOutPixelData16x16, 4);
+        });
+        Log.v(TAG, "Elapsed Time For getting 16x16 bitmap: " + elapsedTime16x16);
+
+        // You have to unwatch pixel
+        fBPixelManager.unwatchPixels(samePixelData);
+    }
+}

--- a/app/src/androidTest/java/com/canvearth/canvearth/ServerPerformanceTest.java
+++ b/app/src/androidTest/java/com/canvearth/canvearth/ServerPerformanceTest.java
@@ -63,7 +63,7 @@ public class ServerPerformanceTest {
         float averageUpdated = ((float) totalUpdated) / samePixelData.size();
         float averageElapsedTime = elapsedTime / samePixelData.size();
         Log.i(TAG, "Average Elapsed Time: " + averageElapsedTime
-                + ", Average Updated Number: " + averageUpdated);
+                + "ms, Average Updated Number: " + averageUpdated);
         // You have to unwatch pixel
         fBPixelManager.unwatchPixels(samePixelData);
     }
@@ -85,12 +85,12 @@ public class ServerPerformanceTest {
         long elapsedTime8x8 = TimeUtils.measureTimeMillis((Object object) -> {
             fBPixelManager.getBitmapSync(zoomedOutPixelData8x8, 3);
         });
-        Log.v(TAG, "Elapsed Time For getting 8x8 bitmap: " + elapsedTime8x8);
+        Log.i(TAG, "Elapsed Time For getting 8x8 bitmap: " + elapsedTime8x8 + "ms");
         PixelData zoomedOutPixelData16x16 = new PixelData(0, 0, Constants.LEAF_PIXEL_ZOOM_LEVEL - 4);
         long elapsedTime16x16 = TimeUtils.measureTimeMillis((Object object) -> {
             fBPixelManager.getBitmapSync(zoomedOutPixelData16x16, 4);
         });
-        Log.v(TAG, "Elapsed Time For getting 16x16 bitmap: " + elapsedTime16x16);
+        Log.i(TAG, "Elapsed Time For getting 16x16 bitmap: " + elapsedTime16x16 + "ms");
 
         // You have to unwatch pixel
         fBPixelManager.unwatchPixels(samePixelData);

--- a/app/src/main/java/com/canvearth/canvearth/pixel/PixelData.java
+++ b/app/src/main/java/com/canvearth/canvearth/pixel/PixelData.java
@@ -15,6 +15,13 @@ public class PixelData {
         this.firebaseId = Integer.toString(zoom) + "," + Integer.toString(x) + "," + Integer.toString(y);
     }
 
+    public void copyFrom(PixelData pixelData) {
+        this.x = pixelData.x;
+        this.y = pixelData.y;
+        this.zoom = pixelData.zoom;
+        this.firebaseId = pixelData.firebaseId;
+    }
+
     public boolean isLeaf() {
         return zoom == Constants.LEAF_PIXEL_ZOOM_LEVEL;
     }

--- a/app/src/main/java/com/canvearth/canvearth/server/FBPixelManager.java
+++ b/app/src/main/java/com/canvearth/canvearth/server/FBPixelManager.java
@@ -174,7 +174,7 @@ public class FBPixelManager {
         return bitmap;
     }
 
-
+    // TODO Even this may block main thread.
     public void writePixelAsync(PixelData pixelData, Color color, @Nullable Function<PixelData> callback) {
         try {
             if (!pixelData.isLeaf()) {

--- a/app/src/main/java/com/canvearth/canvearth/utils/DatabaseUtils.java
+++ b/app/src/main/java/com/canvearth/canvearth/utils/DatabaseUtils.java
@@ -12,4 +12,9 @@ public class DatabaseUtils {
             return database.child(Constants.FIREBASE_PROD_PREFIX).child(pixelId);
         }
     }
+
+    public static void clearDev() {
+        DatabaseReference database = FirebaseDatabase.getInstance().getReference();
+        database.child(Constants.FIREBASE_DEV_PREFIX).removeValue();
+    }
 }

--- a/app/src/main/java/com/canvearth/canvearth/utils/PixelUtils.java
+++ b/app/src/main/java/com/canvearth/canvearth/utils/PixelUtils.java
@@ -88,4 +88,18 @@ public class PixelUtils {
         }
         return childrenPixelData;
     }
+
+    public static ArrayList<PixelData> makeBatchPixelData(PixelData startPixelData, int numX, int numY) {
+        ArrayList<PixelData> pixelData = new ArrayList<>();
+        for (int x = 0; x < numX; x++) {
+            for (int y = 0; y < numY; y++) {
+                PixelData nearbyPixelData = new PixelData(
+                        startPixelData.x + x,
+                        startPixelData.y + y,
+                        startPixelData.zoom);
+                pixelData.add(nearbyPixelData);
+            }
+        }
+        return pixelData;
+    }
 }

--- a/app/src/main/java/com/canvearth/canvearth/utils/TimeUtils.java
+++ b/app/src/main/java/com/canvearth/canvearth/utils/TimeUtils.java
@@ -1,0 +1,14 @@
+package com.canvearth.canvearth.utils;
+
+import com.canvearth.canvearth.utils.concurrency.Function;
+
+import java.util.concurrent.TimeUnit;
+
+public class TimeUtils {
+    public static long measureTimeMillis(Function<Object> function) {
+        long startTime = System.nanoTime();
+        function.run(null);
+        long endTime = System.nanoTime();
+        return TimeUnit.NANOSECONDS.toMillis(endTime - startTime);
+    }
+}

--- a/app/src/main/java/com/canvearth/canvearth/utils/concurrency/Function.java
+++ b/app/src/main/java/com/canvearth/canvearth/utils/concurrency/Function.java
@@ -1,0 +1,5 @@
+package com.canvearth.canvearth.utils.concurrency;
+
+public interface Function<Input> {
+    void run(Input input);
+}


### PR DESCRIPTION
Resolved #14 
added performance checking module for FBPixelManager.
In mac's android emulator, below was the result.
* ServerPerformanceTest/pixelWritePerformanceTest: Average Elapsed Time: 543.0ms, Average Updated Number: 2.0
* ServerPerformanceTest/bitmapReadPerformanceTest: Elapsed Time For getting 8x8 bitmap: 14ms
* ServerPerformanceTest/bitmapReadPerformanceTest: Elapsed Time For getting 16x16 bitmap: 64ms